### PR TITLE
Prevent accidental navigation during brewing

### DIFF
--- a/src/components/BottomNavigator.vue
+++ b/src/components/BottomNavigator.vue
@@ -29,10 +29,13 @@ export default class BottomNavigator extends Vue {
   @State('bottomNavigator')
   buttons!: BottomNavigatorButtonViewModel[];
 
+  @State('bottomNavigatorDisplay')
+  bottomNavigatorDisplay!: boolean;
+
   bottomNav = '';
 
   get shouldRenderButtons() {
-    return this.buttons?.length > 0;
+    return this.buttons?.length > 0 && this.bottomNavigatorDisplay;
   }
 }
 </script>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -25,6 +25,7 @@ const routes = [
     component: () => import(/* webpackChunkName: "createBrew" */ '../views/brews/createBrew.vue'),
     meta: {
       showBackIcon: true,
+      bottomNavigationDisplay: false,
     },
   },
   {
@@ -66,6 +67,12 @@ router.beforeEach((to, from, next) => {
     store.commit('SET_BACK_NAV_ICON', true);
   } else {
     store.commit('SET_BACK_NAV_ICON', false);
+  }
+
+  if (to.matched.some((record) => record.meta.bottomNavigationDisplay)) {
+    store.commit('SET_BOTTOM_NAVIGATION_DISPLAY', true);
+  } else {
+    store.commit('SET_BOTTOM_NAVIGATION_DISPLAY', false);
   }
 
   next();

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -37,6 +37,7 @@ export interface State {
   brews: {[brewId: string]: Brew};
   user: User;
   bottomNavigator: BottomNavigatorButtonViewModel[];
+  bottomNavigatorDisplay: boolean;
   topNavigator: BottomNavigatorButtonViewModel[];
   appUpdated: boolean;
   beansResultsExhausted: boolean;
@@ -59,6 +60,7 @@ export default new Vuex.Store<State>({
       },
     },
     bottomNavigator: [],
+    bottomNavigatorDisplay: true,
     topNavigator: [],
     appUpdated: false,
     beansResultsExhausted: false,
@@ -110,6 +112,9 @@ export default new Vuex.Store<State>({
     },
     SET_BACK_NAV_ICON(state, showBack) {
       state.showBack = showBack;
+    },
+    SET_BOTTOM_NAVIGATION_DISPLAY(state, shouldDisplay) {
+      state.bottomNavigatorDisplay = shouldDisplay;
     },
     SET_BOTTOM_NAVIGATION(state, bottomNavigatorButtonViewModels) {
       state.bottomNavigator = bottomNavigatorButtonViewModels;

--- a/src/views/brews/createBrew.vue
+++ b/src/views/brews/createBrew.vue
@@ -148,7 +148,7 @@
             class="px-5 pt-5"
           >
             <h1 class="display-3"
-              @click.stop="showEditTimeDialog"
+              @click.stop="onTimerClicked"
             >
               <v-progress-circular
                 id="brewStepCircularProgress"
@@ -233,6 +233,7 @@
                   class="mb-5"
                   block
                   color="secondary"
+                  :disabled="timerRunning"
                 >
                   Reset
                 </v-btn>
@@ -357,7 +358,7 @@ import {
 import Bean from '@/models/beans';
 import Brew from '@/models/brew';
 import SelectedBeanCard from '@/components/brews/selectedBeanCard.vue';
-import { Route } from 'vue-router';
+import { NavigationGuardNext, Route } from 'vue-router';
 import NoSleep from 'nosleep.js';
 import formatTime from '@/utils/timeUtils';
 import BottomNavigatorButtonViewModel from '../../components/bottomNavigator/bottomNavigatorButtonViewModel';
@@ -371,6 +372,17 @@ import BrewRecipeStep from './brewRecipeStep';
   data: () => ({
     brewStepField: 1,
   }),
+  beforeRouteUpdate(to: Route, from: Route, next: NavigationGuardNext<CreateBrew>) {
+    const isStepChange = Number(to.query.brewStep) !== this.brewStep;
+
+    const shouldBlockUpdate = isStepChange && this.timerRunning;
+
+    if (shouldBlockUpdate) {
+      next(false);
+    } else {
+      next();
+    }
+  },
 })
 export default class CreateBrew extends Vue {
     selectedBean: Bean = new Bean();
@@ -424,6 +436,9 @@ export default class CreateBrew extends Vue {
       }
     }
 
+    @Mutation('SET_BOTTOM_NAVIGATION_DISPLAY')
+    setBottomNavigationDisplay!: (shouldDisplay: boolean) => void;
+
     get brewStep() {
       return this.brewStepField;
     }
@@ -435,6 +450,12 @@ export default class CreateBrew extends Vue {
     // eslint-disable-next-line class-methods-use-this
     formatBrewTime(timestamp: number) {
       return formatTime(timestamp, false);
+    }
+
+    onTimerClicked() {
+      if (!this.timerRunning) {
+        this.showEditTimeDialog();
+      }
     }
 
     showEditTimeDialog() {
@@ -739,6 +760,7 @@ export default class CreateBrew extends Vue {
 
     async mounted() {
       this.setTopNavigation([]);
+      this.setBottomNavigationDisplay(false);
 
       if (this.$route.query.brewStep) {
         this.brewStepField = Number(this.$route.query.brewStep);


### PR DESCRIPTION
Many coffees were ruined when you accidentally hit a button.

This PR adds navigation guards and hides UI elements that would take you away from the brewing screen.